### PR TITLE
Fix screen session check

### DIFF
--- a/install_mc_server.sh
+++ b/install_mc_server.sh
@@ -115,7 +115,7 @@ fi
 cat > start.sh <<EOF
 #!/bin/bash
 cd "\$(dirname "\$0")"
-if screen -list | grep -q "$SERVER_NAME"; then
+if screen -list | grep -wq "$SERVER_NAME"; then
   echo "Server '\$SERVER_NAME' is already running."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- match screen session exactly using `grep -w`
- regenerate and verify `start.sh`

## Testing
- `bash -n install_mc_server.sh`
- ran installer with default options to generate `start.sh`

